### PR TITLE
optional trinity track loaded correctly

### DIFF
--- a/create_fusion_report.py
+++ b/create_fusion_report.py
@@ -49,7 +49,8 @@ def create_fusion_report(template):
                 i += 1
             filename = line[start:i]
             output_lines.append(line[:start - 1] + 'data["' + filename + '"]' + line[i+1:])
-            data_uris[filename] = data_uri.file_to_data_uri(os.path.join(basedir, filename))
+            if os.path.exists(os.path.join(basedir, filename)):
+                data_uris[filename] = data_uri.file_to_data_uri(os.path.join(basedir, filename))
 
         elif json_line >= 0:
             i += 6

--- a/example/FI_viewer/igvjs_fusion.html
+++ b/example/FI_viewer/igvjs_fusion.html
@@ -228,7 +228,7 @@
                 ]
             };
 
-        if ("finspector.gmap_trinity_GG.fusions.gff3.bed.sorted.bed") {
+        if (data["finspector.gmap_trinity_GG.fusions.gff3.bed.sorted.bed"]) {
             options.tracks.push({
                 label: "Trinity_Fusion",
                 url: "finspector.gmap_trinity_GG.fusions.gff3.bed.sorted.bed",


### PR DESCRIPTION
create_fusion_report.py - checks if trinity BED files exists
example/FI_viewer/igvjs_fusion.html - if data["finspector.gmap_trinity_GG.fusions.gff3.bed.sorted.bed"] exists then track is pushed to IGV tracks object